### PR TITLE
feat(auth): migrate JWT storage from localStorage to httpOnly cookies

### DIFF
--- a/backend/src/main/java/com/ubs/expensemanager/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ubs/expensemanager/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
   private static final String[] PUBLIC_ENDPOINTS = {
       "/api/auth/login",
       "/api/auth/register",
+      "/api/auth/logout",
 
       "/swagger-ui/**",
       "/v3/api-docs/**",

--- a/backend/src/main/java/com/ubs/expensemanager/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/ubs/expensemanager/security/JwtAuthFilter.java
@@ -3,6 +3,7 @@ package com.ubs.expensemanager.security;
 import com.ubs.expensemanager.service.UserDetailsServiceImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,15 +15,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Filter that checks incoming HTTP requests for a JWT token.
  *
- * <p> Extracts the token from the Authorization header, validates it, and
- * sets the authentication in the SecurityContext if valid. </p>
+ * <p> Extracts the token from cookies (preferred) or Authorization header,
+ * validates it, and sets the authentication in the SecurityContext if valid. </p>
  */
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private static final String JWT_COOKIE_NAME = "jwt_token";
 
     @Autowired
     private JwtUtil jwtUtil;
@@ -30,22 +34,18 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Autowired
     private UserDetailsServiceImpl userDetailsService;
 
-    /**
-     * Filter that checks incoming HTTP requests for a JWT token.
-     *
-     * <p> Extracts the token from the Authorization header, validates it, and
-     * sets the authentication in the SecurityContext if valid. </p>
-     */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String authHeader = request.getHeader("Authorization");
-        String token = null;
-        String username = null;
+        String token = extractTokenFromCookie(request);
 
-        // strips the "Bearer " part
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            token = authHeader.substring(7);
+        // Fallback to Authorization header if no cookie
+        if (token == null) {
+            token = extractTokenFromHeader(request);
+        }
+
+        String username = null;
+        if (token != null) {
             username = jwtUtil.extractUsername(token);
         }
 
@@ -59,5 +59,24 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> JWT_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String extractTokenFromHeader(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
 app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  cookie:
+    secure: ${COOKIE_SECURE:false}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,19 +1,35 @@
 import { Navigate } from "react-router-dom";
 
+interface User {
+  id: number;
+  email: string;
+  role: string;
+}
+
 interface ProtectedRouteProps {
   children: JSX.Element;
   allowedRoles?: string[];
 }
 
-export const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
-  const token = localStorage.getItem("jwt_token");
-  const role = localStorage.getItem("user_role");
+const getUser = (): User | null => {
+  const raw = localStorage.getItem("user");
+  if (!raw) return null;
 
-  // no token -> goto login
-  if (!token) return <Navigate to="/" replace />;
+  try {
+    return JSON.parse(raw) as User;
+  } catch {
+    return null;
+  }
+};
+
+export const ProtectedRoute = ({ children, allowedRoles }: ProtectedRouteProps) => {
+  const user = getUser();
+
+  // no user -> goto login
+  if (!user) return <Navigate to="/" replace />;
 
   // no perm -> goto dashboard
-  if (allowedRoles && !allowedRoles.includes(role || "")) {
+  if (allowedRoles && !allowedRoles.includes(user.role)) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/frontend/src/components/PublicRoute.tsx
+++ b/frontend/src/components/PublicRoute.tsx
@@ -5,10 +5,10 @@ interface PublicRouteProps {
 }
 
 export const PublicRoute = ({ children }: PublicRouteProps) => {
-  const token = localStorage.getItem("jwt_token");
+  const user = localStorage.getItem("user");
 
   // if the user has a session redirect to dashboard
-  if (token) {
+  if (user) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import type { UserRole } from '@/config/navigation';
+import { api } from '@/services/api';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,12 +12,11 @@ export interface User {
 
 const STORAGE_KEYS = {
   USER: 'user',
-  TOKEN: 'jwt_token',
 } as const;
 
 const parseUser = (raw: string | null): User | null => {
   if (!raw) return null;
-  
+
   try {
     return JSON.parse(raw) as User;
   } catch {
@@ -29,18 +29,20 @@ export const useAuth = () => {
   const navigate = useNavigate();
 
   const user = useMemo(() => {
-    const token = localStorage.getItem(STORAGE_KEYS.TOKEN);
-    if (!token) return null;
-    
     return parseUser(localStorage.getItem(STORAGE_KEYS.USER));
   }, []);
 
   const isAuthenticated = useMemo(() => !!user, [user]);
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEYS.TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.USER);
-    navigate('/');
+  const logout = useCallback(async () => {
+    try {
+      await api.post('/api/auth/logout');
+    } catch (error) {
+      console.error('Logout request failed:', error);
+    } finally {
+      localStorage.removeItem(STORAGE_KEYS.USER);
+      navigate('/');
+    }
   }, [navigate]);
 
   const hasRole = useCallback(

--- a/frontend/src/pages/Department/DepartmentPage.tsx
+++ b/frontend/src/pages/Department/DepartmentPage.tsx
@@ -23,13 +23,25 @@ import { DepartmentForm } from "./components/DepartmentForm";
  * - Correct Create flow resets editing state
  */
 
+const getUserRole = (): string | null => {
+  const raw = localStorage.getItem("user");
+  if (!raw) return null;
+
+  try {
+    const user = JSON.parse(raw) as { role: string };
+    return user.role;
+  } catch {
+    return null;
+  }
+};
+
 export const DepartmentPage = () => {
   const [departments, setDepartments] = useState<Department[]>([]);
   const [editing, setEditing] = useState<Department | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const role = localStorage.getItem("user_role");
+  const role = getUserRole();
   const canEdit = role === "FINANCE" || role === "ROLE_FINANCE";
 
   async function loadDepartments() {

--- a/frontend/src/pages/Login/components/LoginForm.tsx
+++ b/frontend/src/pages/Login/components/LoginForm.tsx
@@ -64,9 +64,9 @@ export const LoginForm = () => {
         data
       );
 
-      localStorage.setItem('jwt_token', result.token);
+      // Store only user info for UI purposes
+      // JWT token is handled via httpOnly cookie
       localStorage.setItem('user', JSON.stringify(result.user));
-      localStorage.setItem('user_role', result.user.role);
 
       navigate('/dashboard');
     } catch (error) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -5,10 +5,13 @@ import axios from "axios";
  *
  * This instance is responsible for:
  * - Defining the backend base URL
- * - Automatically attaching the JWT token to every request
+ * - Sending credentials (cookies) with every request
  *
  * All API calls (auth, departments, etc.) must use this instance
  * to ensure consistency and security.
+ *
+ * Authentication is handled via httpOnly cookies set by the backend,
+ * which are automatically sent with each request.
  */
 export const api = axios.create({
   /**
@@ -18,26 +21,12 @@ export const api = axios.create({
    * - Falls back to localhost for local development
    */
   baseURL: import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080",
-});
 
-/**
- * Axios request interceptor.
- *
- * This interceptor runs BEFORE every HTTP request
- * and injects the JWT token (if present) into the Authorization header.
- *
- * This allows the backend (Spring Security) to:
- * - Authenticate the user
- * - Authorize requests based on roles (FINANCE, MANAGER, EMPLOYEE)
- */
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem("jwt_token");
-
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-
-  return config;
+  /**
+   * Enable sending cookies with cross-origin requests.
+   * Required for httpOnly cookie-based authentication.
+   */
+  withCredentials: true,
 });
 
 export default api;


### PR DESCRIPTION
 ## Summary
  - Migrate JWT token storage from localStorage to httpOnly cookies
  - Add logout endpoint to clear authentication cookie
  - Improve security against XSS attacks

  ## Changes

  ### Backend
  - `AuthController.java`: Add httpOnly cookie on login/register, add `/logout` endpoint
  - `JwtAuthFilter.java`: Read token from cookie (with header fallback)
  - `SecurityConfig.java`: Allow `/api/auth/logout` as public endpoint
  - `application.yml`: Add `app.cookie.secure` configuration

  ### Frontend
  - `api.ts`: Add `withCredentials: true`, remove token interceptor
  - `LoginForm.tsx`: Remove `jwt_token` and `user_role` from localStorage
  - `useAuth.ts`: Call logout API, remove only `user` from localStorage
  - `ProtectedRoute.tsx`: Use `user` object instead of `jwt_token`
  - `PublicRoute.tsx`: Use `user` object instead of `jwt_token`
  - `DepartmentPage.tsx`: Use `user.role` instead of `user_role`

  ## Test Plan
  - [x] Login sets httpOnly cookie (check DevTools > Application > Cookies)
  - [x] localStorage contains only `user` object (no `jwt_token`, no `user_role`)
  - [x] `document.cookie` does not expose jwt_token
  - [x] Logout clears cookie and redirects to login
  - [x] Authenticated requests work via cookie
  - [x] Page refresh maintains session

  ## Breaking Change
  JWT token is no longer stored in localStorage. Users will need to re-login after this update.
