### PR TITLE
[EXM-MVP01-23] refactor: remove 'REQUIRES_REVISION' status from expense management

### DIFF
--- a/frontend/src/api/expense.api.ts
+++ b/frontend/src/api/expense.api.ts
@@ -8,8 +8,7 @@ export type ExpenseStatus =
   | "PENDING"
   | "APPROVED_BY_MANAGER"
   | "APPROVED_BY_FINANCE"
-  | "REJECTED"
-  | "REQUIRES_REVISION";
+  | "REJECTED";
 
 /**
  * Expense entity returned by the API

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -73,7 +73,7 @@ export const DashboardPage = () => {
           Dashboard
         </h1>
         <p className='mt-2 text-sm text-gray-600 dark:text-gray-400'>
-          Welcome back, {user?.email}!
+          Welcome back, {user?.name || user?.email}!
         </p>
       </div>
 

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -14,8 +14,6 @@ const getStatusBadgeClasses = (status: ExpenseStatus) => {
       return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
     case 'REJECTED':
       return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
-    case 'REQUIRES_REVISION':
-      return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400';
     default:
       return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
   }
@@ -31,8 +29,6 @@ const getStatusLabel = (status: ExpenseStatus) => {
       return 'Approved (Finance)';
     case 'REJECTED':
       return 'Rejected';
-    case 'REQUIRES_REVISION':
-      return 'Needs Revision';
     default:
       return status;
   }

--- a/frontend/src/pages/Expenses/ExpensesPage.tsx
+++ b/frontend/src/pages/Expenses/ExpensesPage.tsx
@@ -24,7 +24,6 @@ const STATUS_COLORS: Record<ExpenseStatus, string> = {
   APPROVED_BY_MANAGER: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   APPROVED_BY_FINANCE: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
   REJECTED: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  REQUIRES_REVISION: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
 };
 
 const STATUS_LABELS: Record<ExpenseStatus, string> = {
@@ -32,7 +31,6 @@ const STATUS_LABELS: Record<ExpenseStatus, string> = {
   APPROVED_BY_MANAGER: "Approved (Manager)",
   APPROVED_BY_FINANCE: "Approved (Finance)",
   REJECTED: "Rejected",
-  REQUIRES_REVISION: "Needs Revision",
 };
 
 export const ExpensesPage = () => {

--- a/frontend/src/pages/Expenses/components/ExpenseHistoryDialog.tsx
+++ b/frontend/src/pages/Expenses/components/ExpenseHistoryDialog.tsx
@@ -25,7 +25,6 @@ const STATUS_COLORS: Record<string, string> = {
   APPROVED_BY_MANAGER: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   APPROVED_BY_FINANCE: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
   REJECTED: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  REQUIRES_REVISION: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -33,7 +32,6 @@ const STATUS_LABELS: Record<string, string> = {
   APPROVED_BY_MANAGER: "Approved (Manager)",
   APPROVED_BY_FINANCE: "Approved (Finance)",
   REJECTED: "Rejected",
-  REQUIRES_REVISION: "Needs Revision",
 };
 
 export const ExpenseHistoryDialog = ({

--- a/frontend/src/pages/ManageExpenses/ManageExpensesPage.tsx
+++ b/frontend/src/pages/ManageExpenses/ManageExpensesPage.tsx
@@ -22,7 +22,6 @@ const STATUS_COLORS: Record<ExpenseStatus, string> = {
   APPROVED_BY_MANAGER: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
   APPROVED_BY_FINANCE: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
   REJECTED: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  REQUIRES_REVISION: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
 };
 
 const STATUS_LABELS: Record<ExpenseStatus, string> = {
@@ -30,7 +29,6 @@ const STATUS_LABELS: Record<ExpenseStatus, string> = {
   APPROVED_BY_MANAGER: "Approved (Manager)",
   APPROVED_BY_FINANCE: "Approved (Finance)",
   REJECTED: "Rejected",
-  REQUIRES_REVISION: "Needs Revision",
 };
 
 export const ManageExpensesPage = () => {


### PR DESCRIPTION
This pull request removes the `REQUIRES_REVISION` status from the expense management system. The change affects the expense status type definition as well as all places in the frontend where this status was referenced for badge colors and labels.

**Expense Status Removal:**

* Removed the `REQUIRES_REVISION` status from the `ExpenseStatus` type in `frontend/src/api/expense.api.ts`.

**Frontend UI Updates:**

* Removed handling of `REQUIRES_REVISION` from the status badge class function and label function in `frontend/src/pages/Dashboard/DashboardPage.tsx`. [[1]](diffhunk://#diff-efdd58beaa3fc51c29bb7ea5c4e992647fd59a727324d202196bf6c43bced7ecL17-L18) [[2]](diffhunk://#diff-efdd58beaa3fc51c29bb7ea5c4e992647fd59a727324d202196bf6c43bced7ecL34-L35)
* Removed `REQUIRES_REVISION` from the `STATUS_COLORS` and `STATUS_LABELS` objects in `frontend/src/pages/Expenses/ExpensesPage.tsx`.
* Removed `REQUIRES_REVISION` from the `STATUS_COLORS` and `STATUS_LABELS` objects in `frontend/src/pages/Expenses/components/ExpenseHistoryDialog.tsx`.
* Removed `REQUIRES_REVISION` from the `STATUS_COLORS` and `STATUS_LABELS` objects in `frontend/src/pages/ManageExpenses/ManageExpensesPage.tsx`.