### PR TITLE
[EXM-MVP01-23] feat: add calculator-style currency mask to money input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI - Expense Manager
 
-# on:
-#   pull_request:
-#     branches:
-#       - dev
-#       - main
-#   push:
-#     branches:
-#       - dev
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
 
 jobs:
   # ------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI - Expense Manager
 
-on:
-  pull_request:
-    branches:
-      - dev
-      - main
-  push:
-    branches:
-      - dev
+# on:
+#   pull_request:
+#     branches:
+#       - dev
+#       - main
+#   push:
+#     branches:
+#       - dev
 
 jobs:
   # ------------------------

--- a/frontend/src/components/ui/money-input.tsx
+++ b/frontend/src/components/ui/money-input.tsx
@@ -2,27 +2,35 @@ import * as React from 'react';
 import { Input } from './input';
 import { cn } from '@/lib/utils';
 
-// Utility functions for money handling
+const MAX_AMOUNT = 9999999999999.99;
+
+// Parse a formatted string to a number
 const parseMoneyValue = (value: string): number | null => {
   if (!value || value === '') return null;
-  const numberValue = parseFloat(value);
+  const cleanValue = value.replace(/,/g, '');
+  const numberValue = parseFloat(cleanValue);
   if (isNaN(numberValue)) return null;
   return numberValue;
 };
 
+// Format a number with thousand separators and 2 decimal places
 const formatMoneyValue = (amount: number | null): string => {
-  if (amount === null) return '';
-  
+  if (amount === null || amount === 0) return '0.00';
+
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount);
 };
 
-// Maximum value allowed: 13 integer digits + 2 decimal places (database constraint)
-const MAX_AMOUNT = 9999999999999.99;
+// Convert cents (integer) to formatted currency string
+const centsToFormatted = (cents: number): string => {
+  const value = cents / 100;
+  return formatMoneyValue(value);
+};
 
-export interface MoneyInputProps extends Omit<React.ComponentProps<'input'>, 'value' | 'onChange'> {
+export interface MoneyInputProps
+  extends Omit<React.ComponentProps<'input'>, 'value' | 'onChange'> {
   value: number | null;
   currency: string;
   onChange: (value: number | null) => void;
@@ -30,83 +38,130 @@ export interface MoneyInputProps extends Omit<React.ComponentProps<'input'>, 'va
 }
 
 const MoneyInput = React.forwardRef<HTMLInputElement, MoneyInputProps>(
-  ({ className, value, currency, onChange, disabled, maxValue = MAX_AMOUNT, ...props }, ref) => {
-    const [displayValue, setDisplayValue] = React.useState('');
-    const [isFocused, setIsFocused] = React.useState(false);
+  (
+    {
+      className,
+      value,
+      currency,
+      onChange,
+      disabled,
+      maxValue = MAX_AMOUNT,
+      ...props
+    },
+    ref
+  ) => {
+    const [displayValue, setDisplayValue] = React.useState('0.00');
+    const inputRef = React.useRef<HTMLInputElement>(null);
 
-    // Update display value when value changes from outside (not during typing)
+    // Combine refs
+    React.useImperativeHandle(ref, () => inputRef.current!);
+
+    // Update display value when value changes from outside
     React.useEffect(() => {
-      if (!isFocused) {
-        setDisplayValue(value !== null ? value.toString() : '');
-      }
-    }, [value, isFocused]);
+      setDisplayValue(formatMoneyValue(value));
+    }, [value]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const inputValue = e.target.value;
+      const rawInput = e.target.value;
 
-      // Allow empty input
-      if (inputValue === '') {
-        setDisplayValue('');
-        onChange(null);
+      // Extract only digits from input
+      const digits = rawInput.replace(/\D/g, '');
+
+      // Convert to cents (integer)
+      const cents = parseInt(digits, 10) || 0;
+
+      // Convert cents to actual value
+      const newValue = cents / 100;
+
+      // Block values that exceed the maximum
+      if (newValue > maxValue) {
         return;
       }
 
-      // Only allow numbers and a single decimal point
-      // Allow partial inputs like "5." or ".5"
-      const regex = /^\d*\.?\d{0,2}$/;
+      // Format and update
+      const formatted = centsToFormatted(cents);
+      setDisplayValue(formatted);
+      onChange(newValue === 0 ? null : newValue);
+    };
 
-      if (regex.test(inputValue)) {
-        const parsedValue = parseMoneyValue(inputValue);
-
-        // Block values that exceed the maximum
-        if (parsedValue !== null && parsedValue > maxValue) {
-          return;
-        }
-
-        setDisplayValue(inputValue);
-        onChange(parsedValue);
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Allow: backspace, delete, tab, escape, enter
+      if (
+        e.key === 'Backspace' ||
+        e.key === 'Delete' ||
+        e.key === 'Tab' ||
+        e.key === 'Escape' ||
+        e.key === 'Enter'
+      ) {
+        return;
       }
+
+      // Allow: Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
+      if (e.ctrlKey || e.metaKey) {
+        return;
+      }
+
+      // Allow: arrow keys
+      if (e.key.startsWith('Arrow')) {
+        return;
+      }
+
+      // Block non-numeric keys
+      if (!/^\d$/.test(e.key)) {
+        e.preventDefault();
+      }
+    };
+
+    // Always move cursor to end
+    const moveCursorToEnd = () => {
+      requestAnimationFrame(() => {
+        if (inputRef.current) {
+          const len = inputRef.current.value.length;
+          inputRef.current.setSelectionRange(len, len);
+        }
+      });
     };
 
     const handleFocus = () => {
-      setIsFocused(true);
-      // Show raw number when focused
-      if (value !== null) {
-        setDisplayValue(value.toString());
-      }
+      moveCursorToEnd();
     };
 
-    const handleBlur = () => {
-      setIsFocused(false);
-      // Format the number when blurred
-      if (value !== null) {
-        // Ensure we have a valid number and format it properly
-        const formatted = value.toFixed(2);
-        setDisplayValue(formatted);
-      }
+    const handleClick = () => {
+      moveCursorToEnd();
+    };
+
+    const handleSelect = () => {
+      moveCursorToEnd();
     };
 
     return (
-      <div className="relative flex w-full">
-        <div className={cn(
-          "flex h-9 items-center rounded-l-md border border-r-0 border-input bg-transparent px-3 text-sm shadow-xs",
-          disabled && "opacity-50 cursor-not-allowed bg-muted"
-        )}>
-          <span className="font-medium text-muted-foreground whitespace-nowrap">
+      <div className='relative flex w-full'>
+        <div
+          className={cn(
+            'flex h-9 items-center rounded-l-md border border-r-0 border-input bg-transparent px-3 text-sm shadow-xs',
+            disabled && 'opacity-50 cursor-not-allowed bg-muted'
+          )}
+        >
+          <span className='font-medium text-muted-foreground whitespace-nowrap'>
             {currency || '---'}
           </span>
         </div>
         <Input
-          ref={ref}
-          type="text"
-          inputMode="decimal"
-          placeholder="0.00"
+          ref={inputRef}
+          type='text'
+          inputMode='numeric'
+          placeholder='0.00'
           value={displayValue}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           onFocus={handleFocus}
-          onBlur={handleBlur}
+          onClick={handleClick}
+          onSelect={handleSelect}
           disabled={disabled}
-          className={cn("rounded-l-none focus-visible:ring-offset-0", className)}
+          className={cn(
+            'rounded-l-none focus-visible:ring-offset-0',
+            className
+          )}
           {...props}
         />
       </div>

--- a/frontend/src/pages/ManageExpenses/ManageExpensesPage.tsx
+++ b/frontend/src/pages/ManageExpenses/ManageExpensesPage.tsx
@@ -202,14 +202,14 @@ export const ManageExpensesPage = () => {
       key: "amount",
       label: "Amount",
       headerAlign: "right",
-      render: (row) => (
-        <span className="text-right block">
-          {new Intl.NumberFormat("en-US", {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          }).format(row.amount)}
-        </span>
-      ),
+      render: (row) => {
+        const currency = row.currencyName || 'USD';
+        return (
+          <span className="text-right block">
+            {formatCurrency(row.amount ?? 0, currency)}
+          </span>
+        )
+      },
     },
     {
       key: "currencyName",


### PR DESCRIPTION
This pull request significantly refactors the `MoneyInput` component to improve its usability, input validation, and formatting consistency. The main changes include switching to a "cents" based input model, enforcing numeric-only input, and always displaying a formatted currency value. The component now ensures cleaner user experience by auto-formatting input, preventing invalid entries, and always keeping the cursor at the end of the input.

**Major improvements to the `MoneyInput` component:**

_Input handling and validation:_
- Switched to a "cents" model: user input is parsed as digits only, interpreted as cents, and then converted to a formatted dollar amount, which prevents invalid or partial decimal inputs.
- Enforced numeric-only input at the keydown level, blocking all non-numeric and non-control keys, to ensure only valid money values are entered.
- Added a maximum value check (defaulting to 13 integer digits + 2 decimals), blocking any input that would exceed this limit.

_User experience and formatting:_
- The input always displays a formatted currency value (e.g., `1,234.56`), even when the field is focused or being edited, improving clarity for users.
- The cursor is always moved to the end of the input on focus, click, or selection,