### PR TITLE
[EXM-MVP01-23] feat: implement alert validation for expense approval process

### DIFF
--- a/backend/src/main/java/com/ubs/expensemanager/messages/Messages.java
+++ b/backend/src/main/java/com/ubs/expensemanager/messages/Messages.java
@@ -54,6 +54,7 @@ public final class Messages {
   public static final String CANNOT_APPROVE_TERMINAL_STATUS = "Cannot approve expense with terminal status %s";
   public static final String CANNOT_REJECT_TERMINAL_STATUS = "Cannot reject expense with terminal status %s";
   public static final String NO_STATE_FOUND_FOR_STATUS = "No state found for status: %s";
+  public static final String CANNOT_APPROVE_WITH_NEW_ALERT = "Cannot approve expense with unresolved alerts. Please resolve all alerts first.";
 
   // ===== Validation Errors =====
   public static final String USER_EMAIL_EXISTS = "The email '%s' is already registered";

--- a/backend/src/main/java/com/ubs/expensemanager/repository/AlertRepository.java
+++ b/backend/src/main/java/com/ubs/expensemanager/repository/AlertRepository.java
@@ -67,4 +67,13 @@ public interface AlertRepository extends
      * @return a list of alerts matching the criteria
      */
     List<Alert> findAllByExpenseAndTypeAndStatus(Expense expense, AlertType type, AlertStatus status);
+
+    /**
+     * Finds all alerts with the specified expense and status.
+     *
+     * @param expense the expense associated with the alerts
+     * @param status the alert status
+     * @return a list of alerts matching the criteria
+     */
+    List<Alert> findByExpenseAndStatus(Expense expense, AlertStatus status);
 }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -39,6 +39,11 @@ management:
   endpoints:
     enabled-by-default: false
 
+# Scheduler properties for test environment
+BACKEND_ENDPOINT: http://localhost:8080/actuator/health
+ACTUATOR_REQUIRED_USER: test
+ACTUATOR_REQUIRED_PASSWORD: test
+
 logging:
   pattern:
     console: "[%-5level] [${${spring:spring.application.name}}] [%t] [%date{ISO8601}] [%c{1}:%M:%L] [%X{traceId},%X{spanId}] %msg %n"

--- a/backend/src/test/resources/datasets/expense/expected/after-manager-approves-expense-with-resolved-alert.yml
+++ b/backend/src/test/resources/datasets/expense/expected/after-manager-approves-expense-with-resolved-alert.yml
@@ -1,0 +1,54 @@
+PUBLIC.CURRENCIES:
+  - ID: 1
+    NAME: "USD"
+    EXCHANGE_RATE: 1.000000
+
+PUBLIC.DEPARTMENTS:
+  - ID: 101
+    NAME: "IT"
+    DAILY_BUDGET: 400.0
+    MONTHLY_BUDGET: 12000.0
+    CURRENCY_ID: 1
+
+PUBLIC.EXPENSE_CATEGORIES:
+  - ID: 101
+    NAME: "Food"
+    DAILY_BUDGET: 100.0
+    MONTHLY_BUDGET: 3000.0
+    CURRENCY_ID: 1
+
+PUBLIC.USERS:
+  - ID: 101
+    NAME: "Jane Manager"
+    EMAIL: "manager@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "MANAGER"
+    MANAGER_ID: null
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+  - ID: 104
+    NAME: "John Employee"
+    EMAIL: "employee@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "EMPLOYEE"
+    MANAGER_ID: 101
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+
+PUBLIC.EXPENSES:
+  - ID: 101
+    AMOUNT: 50.00
+    DESCRIPTION: "Team lunch"
+    EXPENSE_DATE: "2026-01-08"
+    USER_ID: 104
+    EXPENSE_CATEGORY_ID: 101
+    CURRENCY_ID: 1
+    RECEIPT_URL: "https://example.com/receipts/1.pdf"
+    STATUS: "APPROVED_BY_MANAGER"
+
+PUBLIC.ALERTS:
+  - ID: 1
+    TYPE: "CATEGORY"
+    MESSAGE: "Daily budget exceeded for category 'Food' on 2026-01-08"
+    STATUS: "RESOLVED"
+    EXPENSE_ID: 101

--- a/backend/src/test/resources/datasets/expense/expected/expense-with-new-alert-no-change.yml
+++ b/backend/src/test/resources/datasets/expense/expected/expense-with-new-alert-no-change.yml
@@ -1,0 +1,54 @@
+PUBLIC.CURRENCIES:
+  - ID: 1
+    NAME: "USD"
+    EXCHANGE_RATE: 1.000000
+
+PUBLIC.DEPARTMENTS:
+  - ID: 101
+    NAME: "IT"
+    DAILY_BUDGET: 400.0
+    MONTHLY_BUDGET: 12000.0
+    CURRENCY_ID: 1
+
+PUBLIC.EXPENSE_CATEGORIES:
+  - ID: 101
+    NAME: "Food"
+    DAILY_BUDGET: 100.0
+    MONTHLY_BUDGET: 3000.0
+    CURRENCY_ID: 1
+
+PUBLIC.USERS:
+  - ID: 101
+    NAME: "Jane Manager"
+    EMAIL: "manager@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "MANAGER"
+    MANAGER_ID: null
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+  - ID: 104
+    NAME: "John Employee"
+    EMAIL: "employee@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "EMPLOYEE"
+    MANAGER_ID: 101
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+
+PUBLIC.EXPENSES:
+  - ID: 101
+    AMOUNT: 50.00
+    DESCRIPTION: "Team lunch"
+    EXPENSE_DATE: "2026-01-08"
+    USER_ID: 104
+    EXPENSE_CATEGORY_ID: 101
+    CURRENCY_ID: 1
+    RECEIPT_URL: "https://example.com/receipts/1.pdf"
+    STATUS: "PENDING"
+
+PUBLIC.ALERTS:
+  - ID: 1
+    TYPE: "CATEGORY"
+    MESSAGE: "Daily budget exceeded for category 'Food' on 2026-01-08"
+    STATUS: "NEW"
+    EXPENSE_ID: 101

--- a/backend/src/test/resources/datasets/expense/input/expense-with-new-alert.yml
+++ b/backend/src/test/resources/datasets/expense/input/expense-with-new-alert.yml
@@ -1,0 +1,55 @@
+PUBLIC.CURRENCIES:
+  - ID: 1
+    NAME: "USD"
+    EXCHANGE_RATE: 1.000000
+
+PUBLIC.DEPARTMENTS:
+  - ID: 101
+    NAME: "IT"
+    DAILY_BUDGET: 400.0
+    MONTHLY_BUDGET: 12000.0
+    CURRENCY_ID: 1
+
+PUBLIC.EXPENSE_CATEGORIES:
+  - ID: 101
+    NAME: "Food"
+    DAILY_BUDGET: 100.0
+    MONTHLY_BUDGET: 3000.0
+    CURRENCY_ID: 1
+
+PUBLIC.USERS:
+  - ID: 101
+    NAME: "Jane Manager"
+    EMAIL: "manager@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "MANAGER"
+    MANAGER_ID: null
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+  - ID: 104
+    NAME: "John Employee"
+    EMAIL: "employee@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "EMPLOYEE"
+    MANAGER_ID: 101
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+
+PUBLIC.EXPENSES:
+  - ID: 101
+    AMOUNT: 50.00
+    DESCRIPTION: "Team lunch"
+    EXPENSE_DATE: "2026-01-08"
+    USER_ID: 104
+    EXPENSE_CATEGORY_ID: 101
+    CURRENCY_ID: 1
+    RECEIPT_URL: "https://example.com/receipts/1.pdf"
+    STATUS: "PENDING"
+
+PUBLIC.ALERTS:
+  - ID: 1
+    TYPE: "CATEGORY"
+    MESSAGE: "Daily budget exceeded for category 'Food' on 2026-01-08"
+    STATUS: "NEW"
+    EXPENSE_ID: 101
+    CREATED_AT: "2026-01-08 10:15:30"

--- a/backend/src/test/resources/datasets/expense/input/expense-with-resolved-alert.yml
+++ b/backend/src/test/resources/datasets/expense/input/expense-with-resolved-alert.yml
@@ -1,0 +1,55 @@
+PUBLIC.CURRENCIES:
+  - ID: 1
+    NAME: "USD"
+    EXCHANGE_RATE: 1.000000
+
+PUBLIC.DEPARTMENTS:
+  - ID: 101
+    NAME: "IT"
+    DAILY_BUDGET: 400.0
+    MONTHLY_BUDGET: 12000.0
+    CURRENCY_ID: 1
+
+PUBLIC.EXPENSE_CATEGORIES:
+  - ID: 101
+    NAME: "Food"
+    DAILY_BUDGET: 100.0
+    MONTHLY_BUDGET: 3000.0
+    CURRENCY_ID: 1
+
+PUBLIC.USERS:
+  - ID: 101
+    NAME: "Jane Manager"
+    EMAIL: "manager@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "MANAGER"
+    MANAGER_ID: null
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+  - ID: 104
+    NAME: "John Employee"
+    EMAIL: "employee@ubs.com"
+    PASSWORD: "$2a$10$fakehashedpassword"
+    ROLE: "EMPLOYEE"
+    MANAGER_ID: 101
+    DEPARTMENT_ID: 101
+    ACTIVE: true
+
+PUBLIC.EXPENSES:
+  - ID: 101
+    AMOUNT: 50.00
+    DESCRIPTION: "Team lunch"
+    EXPENSE_DATE: "2026-01-08"
+    USER_ID: 104
+    EXPENSE_CATEGORY_ID: 101
+    CURRENCY_ID: 1
+    RECEIPT_URL: "https://example.com/receipts/1.pdf"
+    STATUS: "PENDING"
+
+PUBLIC.ALERTS:
+  - ID: 1
+    TYPE: "CATEGORY"
+    MESSAGE: "Daily budget exceeded for category 'Food' on 2026-01-08"
+    STATUS: "RESOLVED"
+    EXPENSE_ID: 101
+    CREATED_AT: "2026-01-08 10:15:30"


### PR DESCRIPTION
This pull request introduces a new validation to the expense approval process, ensuring that expenses with unresolved (NEW) alerts cannot be approved. The changes include updates to the service logic, repository, error messages, and comprehensive test coverage for the new behavior.

**Expense Approval Logic Enhancements:**

* The `ExpenseService.approve` method now checks for unresolved alerts (`AlertStatus.NEW`) before allowing an expense to be approved. If any such alerts exist, approval is blocked and a clear error message is returned. [[1]](diffhunk://#diff-af2c07a8b8d33c5e40c6445ac4bf04c2ff19bc1c8f5e88d26b908a80b2d1c2b1R235-R239) [[2]](diffhunk://#diff-9511db866a4276947adec57637dc6eab44418c6a20601835fd0141f2da1db4b9R57)
* A new repository method `findByExpenseAndStatus` was added to `AlertRepository` to efficiently query alerts by expense and status.

**Error Messaging:**

* A user-friendly error message (`CANNOT_APPROVE_WITH_NEW_ALERT`) was added to the `Messages` class to inform users attempting to approve expenses with unresolved alerts.

**Testing Improvements:**

* New and updated integration and unit tests verify that:
  - Approval is blocked with a 400 error if there are NEW alerts, and the error message is returned.
  - Approval succeeds if all alerts are resolved.
  - Appropriate database state is asserted using new test datasets. [[1]](diffhunk://#diff-14dad1230988dccae660dcf8919925b9270e9446f58c0d8e832c9e19886dc2c9R863-R924) [[2]](diffhunk://#diff-b3fcf10c0e80c938dab2d86f91e7361ccfc26ce647d24879a971cc6964b1d61dR769-R811) [[3]](diffhunk://#diff-e59253fc992b05887f2888e4613d5091fb4898d5a9a2a1d59091f764aad66f35R1-R55) [[4]](diffhunk://#diff-0f6f242cdbe60fddb1aabfb4691bb24219c49fd066dd6f4bcf70e624b11bf1ceR1-R55) [[5]](diffhunk://#diff-70434f9cb1bfd837c095cb9735206ca3eabe4549be29d2abf7635bd7e1b1428eR1-R54) [[6]](diffhunk://#diff-a85c329c1ee8ba556de37b20d7b5f8e69cf42c4fb534c6be382957864b19105dR1-R54)
* Minor improvements to existing test assertions for clarity and grouping.

These changes strengthen data integrity by preventing the approval of expenses that require attention, and ensure the new behavior is robustly tested.